### PR TITLE
feat: Allow users to choose if 'null/None' fields are ignored or not …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,15 @@ lazy val basicSettings = Seq(
     ),
     ProblemFilters.exclude[MissingClassProblem](
       "net.nmoncho.helenus.api.cql.ScalaPreparedStatement$BoundStatementOps$"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "net.nmoncho.helenus.api.cql.StatementOptions.copy*"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "net.nmoncho.helenus.api.cql.StatementOptions.this"
+    ),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "net.nmoncho.helenus.api.cql.StatementOptions.copy*"
     )
   )
 )

--- a/core/src/main/scala/net/nmoncho/helenus/api/cql/Options.scala
+++ b/core/src/main/scala/net/nmoncho/helenus/api/cql/Options.scala
@@ -57,68 +57,89 @@ trait Options[In, Out] {
   def applyOptions(bs: BoundStatement): BoundStatement =
     options(bs)
 
+  /** Sets whether the [[BoundStatement]] will ignore `null` bind parameters or not.
+    *
+    * Ignored bind parameters are <em>not</em> the same as `null`, they are <em>missing</em> values.
+    *
+    * @return new [[ScalaPreparedStatement]] instance with (not) ignored null fields
+    */
+  def withIgnoreNullFields(ignore: Boolean): Self =
+    withOptions(options.copy(pstmtOptions = options.pstmtOptions.copy(ignoreNullFields = ignore)))
+
   /** Sets the [[DriverExecutionProfile]] for this statement
     *
-    * @return new [[BoundStatement]] instance with execution profile
+    * @return new [[ScalaPreparedStatement]] instance with execution profile
     */
   def withExecutionProfile(profile: DriverExecutionProfile): Self =
-    withOptions(options.copy(profile = Some(profile)))
+    withOptions(options.copy(bstmtOptions = options.bstmtOptions.copy(profile = Some(profile))))
 
   /** Sets the <a href="https://docs.datastax.com/en/developer/java-driver/latest/manual/core/statements/per_query_keyspace/#relation-to-the-routing-keyspace">Routing Keyspace</a> for this statement
     *
-    * @return new [[BoundStatement]] instance with the routing keyspace
+    * @return new [[ScalaPreparedStatement]] instance with the routing keyspace
     */
   def withRoutingKeyspace(routingKeyspace: CqlIdentifier): Self =
-    withOptions(options.copy(routingKeyspace = Some(routingKeyspace)))
+    withOptions(
+      options.copy(bstmtOptions =
+        options.bstmtOptions.copy(routingKeyspace = Some(routingKeyspace))
+      )
+    )
 
   /** Sets the <a href="https://docs.datastax.com/en/developer/java-driver/latest/manual/core/statements/per_query_keyspace/#relation-to-the-routing-keyspace">Routing Key</a> for this statement
     *
     * For composite Routing Keys, see [[com.datastax.oss.driver.internal.core.util.RoutingKey]]
     *
-    * @return new [[BoundStatement]] instance with the routing key
+    * @return new [[ScalaPreparedStatement]] instance with the routing key
     */
   def withRoutingKey(routingKey: ByteBuffer): Self =
-    withOptions(options.copy(routingKey = Some(routingKey)))
+    withOptions(
+      options.copy(bstmtOptions = options.bstmtOptions.copy(routingKey = Some(routingKey)))
+    )
 
   /** Enables/Disables <a href="https://docs.datastax.com/en/developer/java-driver/latest/manual/core/tracing/">tracing</a> on this statement
     *
-    * @return new [[BoundStatement]] instance with/out tracing
+    * @return new [[ScalaPreparedStatement]] instance with/out tracing
     */
   def withTracing(enabled: Boolean): Self =
-    withOptions(options.copy(tracing = enabled))
+    withOptions(options.copy(bstmtOptions = options.bstmtOptions.copy(tracing = enabled)))
 
   /** Sets the query timeout for this statement
     *
-    * @return new [[BoundStatement]] instance with timeout
+    * @return new [[ScalaPreparedStatement]] instance with timeout
     */
   def withTimeout(timeout: Duration): Self =
-    withOptions(options.copy(timeout = Some(timeout)))
+    withOptions(options.copy(bstmtOptions = options.bstmtOptions.copy(timeout = Some(timeout))))
 
   /** Sets the Paging State for this statement
     *
-    * @return new [[BoundStatement]] instance with paging state
+    * @return new [[ScalaPreparedStatement]] instance with paging state
     */
   def withPagingState(pagingState: ByteBuffer): Self =
-    withOptions(options.copy(pagingState = Some(pagingState)))
+    withOptions(
+      options.copy(bstmtOptions = options.bstmtOptions.copy(pagingState = Some(pagingState)))
+    )
 
   /** Sets the [[PagingState]] for this statement
     *
-    * @return new [[BoundStatement]] instance with paging state
+    * @return new [[ScalaPreparedStatement]] instance with paging state
     */
   def withPagingState(pagingState: PagingState): Self =
     withPagingState(pagingState.getRawPagingState)
 
   /** Sets the page size for this statement
     *
-    * @return new [[BoundStatement]] instance with page size
+    * @return new [[ScalaPreparedStatement]] instance with page size
     */
   def withPageSize(pageSize: Int): Self =
-    withOptions(options.copy(pageSize = pageSize))
+    withOptions(options.copy(bstmtOptions = options.bstmtOptions.copy(pageSize = pageSize)))
 
   /** Sets the [[ConsistencyLevel]] for this statement
     *
-    * @return new [[BoundStatement]] instance with consistency level
+    * @return new [[ScalaPreparedStatement]] instance with consistency level
     */
   def withConsistencyLevel(consistencyLevel: ConsistencyLevel): Self =
-    withOptions(options.copy(consistencyLevel = Some(consistencyLevel)))
+    withOptions(
+      options.copy(bstmtOptions =
+        options.bstmtOptions.copy(consistencyLevel = Some(consistencyLevel))
+      )
+    )
 }

--- a/core/src/main/scala/net/nmoncho/helenus/api/cql/StatementOptions.scala
+++ b/core/src/main/scala/net/nmoncho/helenus/api/cql/StatementOptions.scala
@@ -28,60 +28,118 @@ import com.datastax.oss.driver.api.core.ConsistencyLevel
 import com.datastax.oss.driver.api.core.CqlIdentifier
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile
 import com.datastax.oss.driver.api.core.cql.BoundStatement
+import net.nmoncho.helenus.api.cql.StatementOptions.BoundStatementOptions
+import net.nmoncho.helenus.api.cql.StatementOptions.PreparedStatementOptions
 
-/** Defines a set of options to apply on a [[BoundStatement]]
-  *
-  * @param profile A profile in the driver's configuration.
-  * @param routingKeyspace Sets the keyspace to use for token-aware routing.
-  * @param routingKey Sets the key to use for token-aware routing.
-  * @param tracing Sets tracing for execution.
-  * @param timeout Sets how long to wait for this request to complete.
-  * @param pagingState Sets the paging state to send with the statement
-  * @param pageSize Configures how many rows will be retrieved simultaneously in a single network roundtrip
-  * @param consistencyLevel Sets the [[ConsistencyLevel]] to use for this statement.
+/** Defines a set of options to apply on a [[ScalaPreparedStatement]]
   */
 case class StatementOptions(
-    profile: Option[DriverExecutionProfile],
-    routingKeyspace: Option[CqlIdentifier],
-    routingKey: Option[ByteBuffer],
-    tracing: Boolean,
-    timeout: Option[Duration],
-    pagingState: Option[ByteBuffer],
-    pageSize: Int,
-    consistencyLevel: Option[ConsistencyLevel]
+    pstmtOptions: PreparedStatementOptions,
+    bstmtOptions: BoundStatementOptions
 ) {
 
   /** Applies the specified options to the provided [[BoundStatement]]
     * @return [[BoundStatement]] with the applied options
     */
   def apply(bs: BoundStatement): BoundStatement =
-    if (this == StatementOptions.default) bs
+    if (bstmtOptions == StatementOptions.default.bstmtOptions) bs
     else {
       // TODO maybe we can avoid so many allocations with a simple `new`, although it would be less flexible
-      val bs1 = bs.setTracing(tracing).setPageSize(pageSize)
-      val bs2 = profile.map(bs1.setExecutionProfile).getOrElse(bs1)
-      val bs3 = routingKeyspace.map(bs2.setRoutingKeyspace).getOrElse(bs2)
-      val bs4 = routingKey.map(bs3.setRoutingKey).getOrElse(bs3)
-      val bs5 = timeout.map(bs4.setTimeout).getOrElse(bs4)
-      val bs6 = pagingState.map(bs5.setPagingState).getOrElse(bs5)
+      val bs1 = bs.setTracing(bstmtOptions.tracing).setPageSize(bstmtOptions.pageSize)
+      val bs2 = bstmtOptions.profile.map(bs1.setExecutionProfile).getOrElse(bs1)
+      val bs3 = bstmtOptions.routingKeyspace.map(bs2.setRoutingKeyspace).getOrElse(bs2)
+      val bs4 = bstmtOptions.routingKey.map(bs3.setRoutingKey).getOrElse(bs3)
+      val bs5 = bstmtOptions.timeout.map(bs4.setTimeout).getOrElse(bs4)
+      val bs6 = bstmtOptions.pagingState.map(bs5.setPagingState).getOrElse(bs5)
 
-      consistencyLevel.map(bs6.setConsistencyLevel).getOrElse(bs6)
+      bstmtOptions.consistencyLevel.map(bs6.setConsistencyLevel).getOrElse(bs6)
     }
+
+  def ignoreNullFields: Boolean = pstmtOptions.ignoreNullFields
+
+  def profile: Option[DriverExecutionProfile] = bstmtOptions.profile
+
+  def routingKeyspace: Option[CqlIdentifier] = bstmtOptions.routingKeyspace
+
+  def routingKey: Option[ByteBuffer] = bstmtOptions.routingKey
+
+  def tracing: Boolean = bstmtOptions.tracing
+
+  def timeout: Option[Duration] = bstmtOptions.timeout
+
+  def pagingState: Option[ByteBuffer] = bstmtOptions.pagingState
+
+  def pageSize: Int = bstmtOptions.pageSize
+
+  def consistencyLevel: Option[ConsistencyLevel] = bstmtOptions.consistencyLevel
 
 }
 
 object StatementOptions {
 
+  def apply(
+      profile: Option[DriverExecutionProfile],
+      routingKeyspace: Option[CqlIdentifier],
+      routingKey: Option[ByteBuffer],
+      tracing: Boolean,
+      timeout: Option[Duration],
+      pagingState: Option[ByteBuffer],
+      pageSize: Int,
+      consistencyLevel: Option[ConsistencyLevel]
+  ): StatementOptions =
+    StatementOptions(
+      default.pstmtOptions,
+      BoundStatementOptions(
+        profile,
+        routingKeyspace,
+        routingKey,
+        tracing,
+        timeout,
+        pagingState,
+        pageSize,
+        consistencyLevel
+      )
+    )
+
+  case class PreparedStatementOptions(ignoreNullFields: Boolean)
+
+  /** Defines a set of options to apply on a [[BoundStatement]]
+    *
+    * @param profile          A profile in the driver's configuration.
+    * @param routingKeyspace  Sets the keyspace to use for token-aware routing.
+    * @param routingKey       Sets the key to use for token-aware routing.
+    * @param tracing          Sets tracing for execution.
+    * @param timeout          Sets how long to wait for this request to complete.
+    * @param pagingState      Sets the paging state to send with the statement
+    * @param pageSize         Configures how many rows will be retrieved simultaneously in a single network roundtrip
+    * @param consistencyLevel Sets the [[ConsistencyLevel]] to use for this statement.
+    */
+  case class BoundStatementOptions(
+      profile: Option[DriverExecutionProfile],
+      routingKeyspace: Option[CqlIdentifier],
+      routingKey: Option[ByteBuffer],
+      tracing: Boolean,
+      timeout: Option[Duration],
+      pagingState: Option[ByteBuffer],
+      pageSize: Int,
+      consistencyLevel: Option[ConsistencyLevel]
+  )
+
   /** Default Options, takes all configuration options from the session */
   final val default: StatementOptions = StatementOptions(
-    profile          = None,
-    routingKeyspace  = None,
-    routingKey       = None,
-    tracing          = false,
-    timeout          = None,
-    pagingState      = None,
-    pageSize         = 0, // 0 or negative uses default value defined in configuration
-    consistencyLevel = None
+    PreparedStatementOptions(
+      ignoreNullFields = true
+    ),
+    BoundStatementOptions(
+      profile          = None,
+      routingKeyspace  = None,
+      routingKey       = None,
+      tracing          = false,
+      timeout          = None,
+      pagingState      = None,
+      pageSize         = 0, // 0 or negative uses default value defined in configuration
+      consistencyLevel = None
+    )
   )
 
 }

--- a/core/src/main/scala/net/nmoncho/helenus/internal/cql/ScalaPreparedStatement.scala
+++ b/core/src/main/scala/net/nmoncho/helenus/internal/cql/ScalaPreparedStatement.scala
@@ -250,8 +250,15 @@ class ScalaPreparedStatement1[T1, Out](pstmt: PreparedStatement, mapper: RowMapp
   verifyArity(t1Codec)
 
   /** Bounds an input [[T1]] value and returns a [[BoundStatement]] */
-  def apply(t1: T1): ScalaBoundStatement[Out] =
-    tag[Out](applyOptions(pstmt.bind().setIfDefined(0, t1, t1Codec)))
+  def apply(t1: T1): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided value.
    *
@@ -374,8 +381,15 @@ class ScalaPreparedStatement2[T1, T2, Out](pstmt: PreparedStatement, mapper: Row
   verifyArity(t1Codec, t2Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2): ScalaBoundStatement[Out] =
-    tag(applyOptions(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec)))
+  def apply(t1: T1, t2: T2): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -429,8 +443,15 @@ class ScalaPreparedStatement3[T1, T2, T3, Out](pstmt: PreparedStatement, mapper:
   verifyArity(t1Codec, t2Codec, t3Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec))
+  def apply(t1: T1, t2: T2, t3: T3): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -484,8 +505,15 @@ class ScalaPreparedStatement4[T1, T2, T3, T4, Out](pstmt: PreparedStatement, map
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -539,8 +567,15 @@ class ScalaPreparedStatement5[T1, T2, T3, T4, T5, Out](pstmt: PreparedStatement,
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -594,8 +629,15 @@ class ScalaPreparedStatement6[T1, T2, T3, T4, T5, T6, Out](pstmt: PreparedStatem
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -649,8 +691,15 @@ class ScalaPreparedStatement7[T1, T2, T3, T4, T5, T6, T7, Out](pstmt: PreparedSt
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -704,8 +753,15 @@ class ScalaPreparedStatement8[T1, T2, T3, T4, T5, T6, T7, T8, Out](pstmt: Prepar
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -759,8 +815,15 @@ class ScalaPreparedStatement9[T1, T2, T3, T4, T5, T6, T7, T8, T9, Out](pstmt: Pr
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -814,8 +877,15 @@ class ScalaPreparedStatement10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Out](pst
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -869,8 +939,15 @@ class ScalaPreparedStatement11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Out
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -924,8 +1001,15 @@ class ScalaPreparedStatement12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -979,8 +1063,15 @@ class ScalaPreparedStatement13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1034,8 +1125,15 @@ class ScalaPreparedStatement14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1089,8 +1187,15 @@ class ScalaPreparedStatement15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1144,8 +1249,15 @@ class ScalaPreparedStatement16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1199,8 +1311,15 @@ class ScalaPreparedStatement17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec, t17Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec).set(16, t17, t17Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1254,8 +1373,15 @@ class ScalaPreparedStatement18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec, t17Codec, t18Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec).set(16, t17, t17Codec).set(17, t18, t18Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1309,8 +1435,15 @@ class ScalaPreparedStatement19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec, t17Codec, t18Codec, t19Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec).set(16, t17, t17Codec).set(17, t18, t18Codec).set(18, t19, t19Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1364,8 +1497,15 @@ class ScalaPreparedStatement20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec, t17Codec, t18Codec, t19Codec, t20Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19, t20: T20): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec).setIfDefined(19, t20, t20Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19, t20: T20): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec).setIfDefined(19, t20, t20Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec).set(16, t17, t17Codec).set(17, t18, t18Codec).set(18, t19, t19Codec).set(19, t20, t20Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1419,8 +1559,15 @@ class ScalaPreparedStatement21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec, t17Codec, t18Codec, t19Codec, t20Codec, t21Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19, t20: T20, t21: T21): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec).setIfDefined(19, t20, t20Codec).setIfDefined(20, t21, t21Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19, t20: T20, t21: T21): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec).setIfDefined(19, t20, t20Codec).setIfDefined(20, t21, t21Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec).set(16, t17, t17Codec).set(17, t18, t18Codec).set(18, t19, t19Codec).set(19, t20, t20Codec).set(20, t21, t21Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *
@@ -1474,8 +1621,15 @@ class ScalaPreparedStatement22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12
   verifyArity(t1Codec, t2Codec, t3Codec, t4Codec, t5Codec, t6Codec, t7Codec, t8Codec, t9Codec, t10Codec, t11Codec, t12Codec, t13Codec, t14Codec, t15Codec, t16Codec, t17Codec, t18Codec, t19Codec, t20Codec, t21Codec, t22Codec)
 
   /** Returns a [[BoundStatement]] with the provided values*/
-  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19, t20: T20, t21: T21, t22: T22): ScalaBoundStatement[Out] =
-    tag(pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec).setIfDefined(19, t20, t20Codec).setIfDefined(20, t21, t21Codec).setIfDefined(21, t22, t22Codec))
+  def apply(t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9, t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16, t17: T17, t18: T18, t19: T19, t20: T20, t21: T21, t22: T22): ScalaBoundStatement[Out] = {
+    val bstmt = if (options.ignoreNullFields) {
+      pstmt.bind().setIfDefined(0, t1, t1Codec).setIfDefined(1, t2, t2Codec).setIfDefined(2, t3, t3Codec).setIfDefined(3, t4, t4Codec).setIfDefined(4, t5, t5Codec).setIfDefined(5, t6, t6Codec).setIfDefined(6, t7, t7Codec).setIfDefined(7, t8, t8Codec).setIfDefined(8, t9, t9Codec).setIfDefined(9, t10, t10Codec).setIfDefined(10, t11, t11Codec).setIfDefined(11, t12, t12Codec).setIfDefined(12, t13, t13Codec).setIfDefined(13, t14, t14Codec).setIfDefined(14, t15, t15Codec).setIfDefined(15, t16, t16Codec).setIfDefined(16, t17, t17Codec).setIfDefined(17, t18, t18Codec).setIfDefined(18, t19, t19Codec).setIfDefined(19, t20, t20Codec).setIfDefined(20, t21, t21Codec).setIfDefined(21, t22, t22Codec)
+    } else {
+      pstmt.bind().set(0, t1, t1Codec).set(1, t2, t2Codec).set(2, t3, t3Codec).set(3, t4, t4Codec).set(4, t5, t5Codec).set(5, t6, t6Codec).set(6, t7, t7Codec).set(7, t8, t8Codec).set(8, t9, t9Codec).set(9, t10, t10Codec).set(10, t11, t11Codec).set(11, t12, t12Codec).set(12, t13, t13Codec).set(13, t14, t14Codec).set(14, t15, t15Codec).set(15, t16, t16Codec).set(16, t17, t17Codec).set(17, t18, t18Codec).set(18, t19, t19Codec).set(19, t20, t20Codec).set(20, t21, t21Codec).set(21, t22, t22Codec)
+    }
+
+    tag[Out](applyOptions(bstmt))
+  }
 
   /** Executes this [[PreparedStatement]] with the provided values
    *

--- a/core/src/test/scala/net/nmoncho/helenus/api/cql/ScalaPreparedStatementSpec.scala
+++ b/core/src/test/scala/net/nmoncho/helenus/api/cql/ScalaPreparedStatementSpec.scala
@@ -223,7 +223,7 @@ class ScalaPreparedStatementSpec
       }
     }
 
-    "not set 'null' parameters" in {
+    "handle 'ignoreNullFields' option" in {
       import scala.jdk.CollectionConverters._
 
       def checkIfPhoneIsSet(bs: BoundStatement, shouldBeSet: Boolean): Unit = {
@@ -240,42 +240,63 @@ class ScalaPreparedStatementSpec
       }
 
       val h2 = Hotels.h2
-      val insertHotel =
-        """INSERT INTO hotels(id, name, phone, address, pois)
-          |VALUES (?, ?, ?, ?, ?)""".stripMargin.toCQL
-          .prepare[String, String, String, Address, Set[String]]
 
-      withClue("when phone is set") {
-        checkIfPhoneIsSet(
-          insertHotel(h2.id, h2.name, h2.phone, h2.address, h2.pois),
-          shouldBeSet = true
-        )
+      withClue("on non-optional columns") {
+        val insertHotel =
+          """INSERT INTO hotels(id, name, phone, address, pois)
+            |VALUES (?, ?, ?, ?, ?)""".stripMargin.toCQL
+            .prepare[String, String, String, Address, Set[String]]
+
+        withClue("when phone is set") {
+          checkIfPhoneIsSet(
+            insertHotel(h2.id, h2.name, h2.phone, h2.address, h2.pois),
+            shouldBeSet = true
+          )
+        }
+
+        withClue("when phone is not set") {
+          checkIfPhoneIsSet(
+            insertHotel(h2.id, h2.name, null, h2.address, h2.pois),
+            shouldBeSet = false
+          )
+        }
+
+        withClue("when not ignoring nulls") {
+          val insertHotelWithNulls = insertHotel.withIgnoreNullFields(ignore = false)
+          checkIfPhoneIsSet(
+            insertHotelWithNulls(h2.id, h2.name, null, h2.address, h2.pois),
+            shouldBeSet = true
+          )
+        }
       }
 
-      withClue("when phone is not set") {
-        checkIfPhoneIsSet(
-          insertHotel(h2.id, h2.name, null, h2.address, h2.pois),
-          shouldBeSet = false
-        )
-      }
+      withClue("on optional columns") {
+        val insertHotel =
+          """INSERT INTO hotels(id, name, phone, address, pois)
+            |VALUES (?, ?, ?, ?, ?)""".stripMargin.toCQL
+            .prepare[String, String, Option[String], Address, Set[String]]
 
-      val insertHotelOpt =
-        """INSERT INTO hotels(id, name, phone, address, pois)
-          |VALUES (?, ?, ?, ?, ?)""".stripMargin.toCQL
-          .prepare[String, String, Option[String], Address, Set[String]]
+        withClue("when phone is set") {
+          checkIfPhoneIsSet(
+            insertHotel(h2.id, h2.name, Some(h2.phone), h2.address, h2.pois),
+            shouldBeSet = true
+          )
+        }
 
-      withClue("when phone is set") {
-        checkIfPhoneIsSet(
-          insertHotelOpt(h2.id, h2.name, Some(h2.phone), h2.address, h2.pois),
-          shouldBeSet = true
-        )
-      }
+        withClue("when phone is not set") {
+          checkIfPhoneIsSet(
+            insertHotel(h2.id, h2.name, None, h2.address, h2.pois),
+            shouldBeSet = false
+          )
+        }
 
-      withClue("when phone is not set") {
-        checkIfPhoneIsSet(
-          insertHotelOpt(h2.id, h2.name, None, h2.address, h2.pois),
-          shouldBeSet = false
-        )
+        withClue("when not ignoring nulls") {
+          val insertHotelWithNulls = insertHotel.withIgnoreNullFields(ignore = false)
+          checkIfPhoneIsSet(
+            insertHotelWithNulls(h2.id, h2.name, None, h2.address, h2.pois),
+            shouldBeSet = true
+          )
+        }
       }
     }
   }

--- a/core/src/test/scala/net/nmoncho/helenus/api/cql/StatementOptionsSpec.scala
+++ b/core/src/test/scala/net/nmoncho/helenus/api/cql/StatementOptionsSpec.scala
@@ -53,17 +53,19 @@ class StatementOptionsSpec extends AnyWordSpec with Matchers {
       // test setup
       val bs = mockBoundStatement()
       val options = StatementOptions.default.copy(
-        routingKeyspace  = Some(CqlIdentifier.fromInternal("foo")),
-        timeout          = Some(Duration.ofSeconds(30)),
-        consistencyLevel = Some(ConsistencyLevel.ONE)
+        bstmtOptions = StatementOptions.default.bstmtOptions.copy(
+          routingKeyspace  = Some(CqlIdentifier.fromInternal("foo")),
+          timeout          = Some(Duration.ofSeconds(30)),
+          consistencyLevel = Some(ConsistencyLevel.ONE)
+        )
       )
 
       // test execution
       options(bs)
 
       // test assertion
-      verify(bs, atMostOnce).setTracing(StatementOptions.default.tracing)
-      verify(bs, atMostOnce).setPageSize(StatementOptions.default.pageSize)
+      verify(bs, atMostOnce).setTracing(StatementOptions.default.bstmtOptions.tracing)
+      verify(bs, atMostOnce).setPageSize(StatementOptions.default.bstmtOptions.pageSize)
       verify(bs, atMostOnce).setRoutingKey(any())
       verify(bs, atMostOnce).setTimeout(any())
       verify(bs, atMostOnce).setConsistencyLevel(any())


### PR DESCRIPTION
…when binding parameters to a statement.

In previous releases all 'null/None' parameters were ignored, but some uses may need to set null on their tables. This is offered through Options which can be accessed like:

```scala
"INSERT INTO hotels(id, name, phone, address, pois) VALUES (?, ?, ?, ?, ?)".stripMargin.toCQL
    .prepare[String, String, String, Address, Set[String]]
    .withIgnoreNullFields(ignore = false)
```

This commit doens't include PreparedStatements using the `Mapping` abstractions (ie. `prepareFrom`)